### PR TITLE
Fix pagination in page picker

### DIFF
--- a/index.php
+++ b/index.php
@@ -71,7 +71,7 @@ Kirby::plugin('oblik/link-field', [
                         'action' => function () {
                             return $this->field()->pagepicker([
                                 'parent' => $this->requestQuery('parent'),
-                                'page' => $this->requestQuery('page') ?? 1,
+                                'page' => $this->requestQuery('page') ?? 1
                             ]);
                         }
                     ]

--- a/index.php
+++ b/index.php
@@ -70,7 +70,8 @@ Kirby::plugin('oblik/link-field', [
                         'method' => 'GET',
                         'action' => function () {
                             return $this->field()->pagepicker([
-                                'parent' => $this->requestQuery('parent')
+                                'parent' => $this->requestQuery('parent'),
+                                'page' => $this->requestQuery('page') ?? 1,
                             ]);
                         }
                     ]


### PR DESCRIPTION
If the site has more the 20 pages the page picker shows a pagination. The navigation of the pagination didn't work. The api endpoint response with the items of page 1 although the request contains page=2 as parameter.

This PR contains a fix for this issue.