### PR TITLE
Add isNotEmpty function

### DIFF
--- a/src/Link.php
+++ b/src/Link.php
@@ -130,6 +130,6 @@ class Link
 	
 	public function isNotEmpty()
 	{
-		return $this->url() !== null;
+		return !$this->isEmpty();
 	}
 }

--- a/src/Link.php
+++ b/src/Link.php
@@ -127,4 +127,9 @@ class Link
 	{
 		return $this->url() === null;
 	}
+	
+	public function isNotEmpty()
+	{
+		return $this->url() !== null;
+	}
 }


### PR DESCRIPTION
This PR adds an isNotEmpty function similar to how negation works with the default Kirby function.

Why? When I can use `$field->isNotEmpty()` in the Kirby universe, I also expect that `$link->isNotEmpty()` exists when working with a Kirby plugin.